### PR TITLE
fix(mainnet-validator): raise gp3 volume to 6,000 IOPS / 156 MB/s

### DIFF
--- a/swannynode-mainnet-validator/README.md
+++ b/swannynode-mainnet-validator/README.md
@@ -94,9 +94,10 @@ Operational notes:
   that work; RAM/page-cache (the reason for 32GB) is what absorbs it.
   Steady-state validation is a different story: live `iostat` showed write
   IOPS at 2,600–2,968 against the old 3,000 ceiling, with `%util` pinned at
-  92–100% and queue depth (`aqu-sz`) around 10 during MDBX write bursts —
-  the volume was genuinely IOPS-bound, and read latency quadrupled
-  (0.87ms → 3.55ms) when it happened, stalling reth's block execution. The
+  92–100% and queue depth (`aqu-sz`) around 10 during RocksDB compaction
+  write bursts (reth 2.x uses RocksDB, not MDBX) — the volume was genuinely
+  IOPS-bound, and read latency quadrupled (0.87ms → 3.55ms) when it
+  happened, stalling reth's block validation. The
   volume is now provisioned at 6,000 IOPS / 156 MB/s (the `r8g.xlarge`
   instance's EBS baseline ceiling) to give steady-state validation headroom.
 

--- a/swannynode-mainnet-validator/README.md
+++ b/swannynode-mainnet-validator/README.md
@@ -94,10 +94,9 @@ Operational notes:
   that work; RAM/page-cache (the reason for 32GB) is what absorbs it.
   Steady-state validation is a different story: live `iostat` showed write
   IOPS at 2,600–2,968 against the old 3,000 ceiling, with `%util` pinned at
-  92–100% and queue depth (`aqu-sz`) around 10 during RocksDB compaction
-  write bursts (reth 2.x uses RocksDB, not MDBX) — the volume was genuinely
-  IOPS-bound, and read latency quadrupled (0.87ms → 3.55ms) when it
-  happened, stalling reth's block validation. The
+  92–100% and queue depth (`aqu-sz`) around 10 during MDBX write bursts —
+  the volume was genuinely IOPS-bound, and read latency quadrupled
+  (0.87ms → 3.55ms) when it happened, stalling reth's block execution. The
   volume is now provisioned at 6,000 IOPS / 156 MB/s (the `r8g.xlarge`
   instance's EBS baseline ceiling) to give steady-state validation headroom.
 

--- a/swannynode-mainnet-validator/README.md
+++ b/swannynode-mainnet-validator/README.md
@@ -13,7 +13,8 @@ Secrets Manager, and daily DLM snapshots. Design spec:
 | `az` | `us-east-2a` | change + snapshot-restore to move AZ |
 | `instanceType` | `r8g.xlarge` | |
 | `volumeSizeGb` | `600` | |
-| `volumeIops` | `3000` | raise if sync is IOPS-bound |
+| `volumeIops` | `6000` | matched to the `r8g.xlarge` EBS baseline ceiling (6,000 IOPS) — going higher would be unusable spend |
+| `volumeThroughput` | `156` | matched to the `r8g.xlarge` EBS baseline ceiling (156.25 MB/s) |
 | `rethVersion` | `v2.4.1` | GitHub release tag |
 | `lighthouseVersion` | `v8.2.0` | GitHub release tag |
 | `mevboostVersion` | `1.12` | GitHub release tag (no `v` in asset name) |
@@ -88,9 +89,15 @@ Operational notes:
   ~2h total). Alternatively, raise the threshold in the reth config
   (`[stages.merkle] clean_threshold`) before restarting reth so a medium gap
   uses the incremental merkle path instead.
-- gp3 sync performance is latency-bound at queue-depth 1, not IOPS-bound —
-  raising provisioned IOPS does not speed up state-root work; RAM/page-cache
-  (the reason for 32GB) is what absorbs it. Steady-state validation is
-  unaffected (blocks validate in 1–3s).
+- A large *sync gap* state-root rebuild (see above) is latency-bound at
+  queue-depth 1, not IOPS-bound — raising provisioned IOPS does not speed up
+  that work; RAM/page-cache (the reason for 32GB) is what absorbs it.
+  Steady-state validation is a different story: live `iostat` showed write
+  IOPS at 2,600–2,968 against the old 3,000 ceiling, with `%util` pinned at
+  92–100% and queue depth (`aqu-sz`) around 10 during MDBX write bursts —
+  the volume was genuinely IOPS-bound, and read latency quadrupled
+  (0.87ms → 3.55ms) when it happened, stalling reth's block execution. The
+  volume is now provisioned at 6,000 IOPS / 156 MB/s (the `r8g.xlarge`
+  instance's EBS baseline ceiling) to give steady-state validation headroom.
 
 **Never** run two copies of this stack (or the old host) against the same keys.

--- a/swannynode-mainnet-validator/storage.go
+++ b/swannynode-mainnet-validator/storage.go
@@ -22,6 +22,7 @@ func createStorage(ctx *pulumi.Context, cfg StackConfig) (*Storage, error) {
 		Size:             pulumi.Int(cfg.VolumeSizeGb),
 		Type:             pulumi.String("gp3"),
 		Iops:             pulumi.Int(cfg.VolumeIops),
+		Throughput:       pulumi.Int(cfg.VolumeThroughput),
 		Tags: pulumi.StringMap{
 			"Name":   pulumi.String("swannynode-mainnet-validator-data"),
 			"Backup": pulumi.String(backupTag),

--- a/swannynode-mainnet-validator/storage_test.go
+++ b/swannynode-mainnet-validator/storage_test.go
@@ -20,6 +20,8 @@ func TestStorageVolumeShape(t *testing.T) {
 	require.Equal(t, 600.0, vol["size"].NumberValue())
 	require.Equal(t, "gp3", vol["type"].StringValue())
 	require.Equal(t, "us-east-2a", vol["availabilityZone"].StringValue())
+	require.Equal(t, 6000.0, vol["iops"].NumberValue())
+	require.Equal(t, 156.0, vol["throughput"].NumberValue())
 	tags := vol["tags"].ObjectValue()
 	require.Equal(t, "swannynode-mainnet-validator", tags["Backup"].StringValue())
 }

--- a/swannynode-mainnet-validator/testmocks_test.go
+++ b/swannynode-mainnet-validator/testmocks_test.go
@@ -44,7 +44,7 @@ func (m *recordingMocks) get(name string) resource.PropertyMap {
 func testCfg() StackConfig {
 	return StackConfig{
 		Az: "us-east-2a", InstanceType: "r8g.xlarge",
-		VolumeSizeGb: 600, VolumeIops: 3000,
+		VolumeSizeGb: 600, VolumeIops: 6000, VolumeThroughput: 156,
 		RethVersion: "v2.4.1", LighthouseVersion: "v8.2.0", MevboostVersion: "1.12",
 		FeeRecipient: "0x0000000000000000000000000000000000000001",
 		KeyName:      "test-key", SshUser: "ec2-user",

--- a/swannynode-mainnet-validator/types.go
+++ b/swannynode-mainnet-validator/types.go
@@ -11,6 +11,7 @@ type StackConfig struct {
 	InstanceType      string
 	VolumeSizeGb      int
 	VolumeIops        int
+	VolumeThroughput  int
 	RethVersion       string
 	LighthouseVersion string
 	MevboostVersion   string
@@ -38,7 +39,8 @@ func loadStackConfig(cfg *config.Config) StackConfig {
 		Az:                getOr(cfg, "az", "us-east-2a"),
 		InstanceType:      getOr(cfg, "instanceType", "r8g.xlarge"),
 		VolumeSizeGb:      getIntOr(cfg, "volumeSizeGb", 600),
-		VolumeIops:        getIntOr(cfg, "volumeIops", 3000),
+		VolumeIops:        getIntOr(cfg, "volumeIops", 6000),
+		VolumeThroughput:  getIntOr(cfg, "volumeThroughput", 156),
 		RethVersion:       getOr(cfg, "rethVersion", "v2.4.1"),
 		LighthouseVersion: getOr(cfg, "lighthouseVersion", "v8.2.0"),
 		MevboostVersion:   getOr(cfg, "mevboostVersion", "1.12"),


### PR DESCRIPTION
## Summary

- Raises the mainnet validator's gp3 chain-data volume from 3,000 IOPS / 125 MB/s to **6,000 IOPS / 156 MB/s**.
- Adds a `VolumeThroughput` field to `StackConfig` (new `volumeThroughput` Pulumi config key, default `156`) alongside the existing `volumeIops` (default now `6000`).

## Evidence

Live `iostat` on the box during steady-state validation showed the volume genuinely saturating its provisioned ceiling:

- Write IOPS: **2,600-2,968** against the **3,000** provisioned cap
- `%util`: pinned at **92-100%**
- Queue depth (`aqu-sz`): **~10**
- Read latency under contention: **0.87ms -> 3.55ms** (quadrupled), stalling reth's block execution

This contradicted the README's prior claim that gp3 performance is purely latency-bound at queue-depth 1 during steady-state validation — that claim is corrected in this PR (the queue-depth-1/latency-bound characterization still holds for the separate large-sync-gap state-root rebuild case, which is unaffected by this change).

## Why 6,000 / 156 and not higher

`r8g.xlarge` itself caps at **6,000 EBS baseline IOPS and 156.25 MB/s** (verified via `aws ec2 describe-instance-types`). Provisioning the volume beyond the instance's own ceiling would be unusable spend — the instance can't push more traffic to the volume than that regardless of what's provisioned on the EBS side.

## Safety note (read before `pulumi up`)

This volume carries live chain data and is `Protect()`ed / `RetainOnDelete`. Before running `pulumi up`:

1. Run `pulumi preview` first and confirm the volume resource shows an **update-in-place**, not a replace or delete. `Iops` and `Throughput` are in-place-modifiable properties on gp3 volumes, so this should be a simple update, but verify before applying.
2. **EBS enforces a ~6-hour cooldown between modifications to the same volume.** If the volume was modified recently (e.g. during troubleshooting), the `pulumi up` may fail or queue until the cooldown elapses.

## Expected impact

This is a **partial mitigation** — roughly 2x IOPS headroom over the current ceiling — not a complete fix. A follow-up investigation into local-NVMe instance types (which would remove EBS as a bottleneck entirely) is in progress separately.

## Test plan

- [x] `gofmt -l .` — no output
- [x] `go build ./...` — succeeds
- [x] `go test ./...` — passes, including new regression assertions in `TestStorageVolumeShape` for `iops` (6000.0) and `throughput` (156.0)
- [ ] `pulumi preview` against the live stack (to be run by the user before `pulumi up`, per safety note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011suPftzGEVQyWswRFvuZ9e
